### PR TITLE
Add Clang-Tidy configuration for GCC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,16 +40,11 @@ endif()
 # === Static analysis ===
 if (ENABLE_STATIC_ANALYSIS)
     find_program(CLANG_TIDY_EXE NAMES clang-tidy)
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CLANG_TIDY_EXE)
         message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
-        if (CLANG_TIDY_EXE)
-            set(CMAKE_CXX_CLANG_TIDY
-                "${CLANG_TIDY_EXE};-config=;--extra-arg=-Wno-stringop-overflow") # remove or override
-        else()
-            set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
-        endif()
+        set(CMAKE_CXX_CLANG_TIDY
+            "${CLANG_TIDY_EXE};-config=;--extra-arg=-Wno-stringop-overflow")
     endif()
-
     find_program(CPPCHECK_EXE NAMES cppcheck)
     if (CPPCHECK_EXE)
         message(STATUS "cppcheck found: ${CPPCHECK_EXE}")


### PR DESCRIPTION
- Introduced Clang-Tidy integration in CMake for GCC builds to suppress stringop-overflow warnings.
- Updated CMakeLists.txt to conditionally set Clang-Tidy options when the executable is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve static analysis consistency for GNU compiler users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->