### PR TITLE
fix: Fix clang-tidy configuration for Codex build environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,14 @@ endif()
 # === Static analysis ===
 if (ENABLE_STATIC_ANALYSIS)
     find_program(CLANG_TIDY_EXE NAMES clang-tidy)
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CLANG_TIDY_EXE)
+    if (CLANG_TIDY_EXE)
         message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
-        set(CMAKE_CXX_CLANG_TIDY
-            "${CLANG_TIDY_EXE};-config=;--extra-arg=-Wno-stringop-overflow")
+        # Only add GCC-specific flags when using GCC compiler
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-config=;--extra-arg=-Wno-stringop-overflow")
+        else()
+            set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-config=")
+        endif()
     endif()
     find_program(CPPCHECK_EXE NAMES cppcheck)
     if (CPPCHECK_EXE)


### PR DESCRIPTION
- Separate clang-tidy detection from compiler-specific flags
- Only add -Wno-stringop-overflow flag when using GCC compiler
- Enable clang-tidy for all compilers with appropriate flags
- Fixes build errors in OpenAI Codex environment using clang

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static analysis configuration to improve compatibility with different compilers when using clang-tidy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->